### PR TITLE
Better redirect page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,26 +1,5 @@
-<!DOCTYPE html>
-<html lang="en">
-
-	<head>
-		<meta charset="UTF-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<title>ScratchAddons Redirect</title>
-		<link rel="favorite icon" href="https://scratchaddons.com/assets/images/icon.svg"
-			  type="img/svg">
-		<style>
-			p {
-				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
-			}
-		</style>
-	</head>
-
-	<body>
-		<p>You will be redirected to <a id="link"
-			   href="https://scratchaddons.com">https://scratchaddons.com</a> shortly. If you are not, try clicking that link and/or enabling JavaScript.</p>
-		<script>
-			document.getElementById("link").href = window.location.href.replace("github.io", "com")
-			window.location.href = window.location.href.replace("github.io", "com")
-		</script>
-	</body>
-
-</html>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="refresh" content="1;url=https://scratchaddons.com/" />
+<style>* {font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;}</style>
+<p>You will be redirected to <a id="link" href="https://scratchaddons.com">https://scratchaddons.com</a> shortly.</p>
+<script>window.location.href = window.location.href.replace("github.io", "com")</script>

--- a/404.html
+++ b/404.html
@@ -1,7 +1,26 @@
-<meta http-equiv="refresh" content="0;url=https://scratchaddons.com/" />
-<p>You will be redirected to <a href="https://scratchaddons.com">https://scratchaddons.com</a> shortly.</p>
-<style>
-* {
-    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif;
-}
-</style>
+<!DOCTYPE html>
+<html lang="en">
+
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>ScratchAddons Redirect</title>
+		<link rel="favorite icon" href="https://scratchaddons.com/assets/images/icon.svg"
+			  type="img/svg">
+		<style>
+			p {
+				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+			}
+		</style>
+	</head>
+
+	<body>
+		<p>You will be redirected to <a id="link"
+			   href="https://scratchaddons.com">https://scratchaddons.com</a> shortly. If you are not, try clicking that link and/or enabling JavaScript.</p>
+		<script>
+			document.getElementById("link").href = window.location.href.replace("github.io", "com")
+			window.location.href = window.location.href.replace("github.io", "com")
+		</script>
+	</body>
+
+</html>


### PR DESCRIPTION
Made it correct HTML structure
Added a title and favicon
Changed the CSS selector to "p" instead of "*" to make it load faster
Before, pages like https://scratchaddons.github.io/feedback would redirect to https://scratchaddons.com. I made it so it would go to https://scratcaddons.com/feedback instead. Yeah, it uses JavaScript, but who disables that anymore? Most of the addons use JS! The Scratch website will not even load without JS! All of our users will probably have it enabled.